### PR TITLE
Caching mentions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/*
 login.js
+*.swp
+*.swo
+*.swn

--- a/functions/mention.js
+++ b/functions/mention.js
@@ -1,33 +1,57 @@
 async = require("async");
 
 module.exports.matchPattern = /@/;
+
+function getIDByFirstName(name, message) {
+    var matchCount = 0;
+    var matchIndex = -1;
+    for (var i in message.participantNames) {
+        if (name.toLowerCase() == message.participantNames[i].toLowerCase()) {
+            matchCount++;
+            matchIndex = i;
+        }
+    }
+    
+    if (matchCount == 1)
+        return message.participantIDs[matchIndex];
+    return null;
+}
+
+function sendMentionMessage(api, mentionedName, mentionedID, message, callback) {
+    api.getUserInfo(message['senderID'], function (err, info) {
+        if (err) {
+            console.log(err);
+            return setImmediate(callback);
+        }
+        else {
+            messageText = "This the HMS facebook bot. You have been mentioned by " + info[Object.getOwnPropertyNames(info)[0]].name + " in the group chat " + message.threadName + ". Here was the message: '" + message.body + "' \n\n If you believe this was done in error, please ignore this.";
+            api.sendMessage(messageText, mentionedID);
+            return setImmediate(callback);
+        }
+    });
+}
+
 //@name lastname must be the format for mentions. They can be put in the middle of sentences. Multiple mentions also work.
 module.exports.action = function (api, message, cb) {
-	async.forEach(message.body.split(module.exports.matchPattern).slice(1), function (frag, callback) {
-		mentioned = frag.split(" ").slice(0,2).join(" ");
-		api.getUserID(mentioned, function (err, ids) {
-			if (err) {
-				console.log(err);
-				var errstring = err['error'];
-				//api.sendMessage({body: errstring}, message.threadID);
-				return setImmediate(callback);
-			} else if (message.participantIDs.indexOf(ids[0]['userID']) == -1 && message.participantIDs.indexOf(parseInt(ids[0]['userID'])) == -1) {
-				console.log("You can only mention people that are in the current thread.");
-				api.sendMessage("You can only mention people that are in the current thread.", message.threadID);
-			} else {
-				var validID = ids[0];
-				api.getUserInfo(message['senderID'], function (err, info) {
-					if (err) {
-						console.log(err);
-						return setImmediate(callback);
-					}
-					else {
-						messageText = "This the HMS facebook bot. You have been mentioned by " + info[Object.getOwnPropertyNames(info)[0]].name + " in the group chat " + message.threadName + ". Here was the message: '" + message.body + "' \n\n If you believe this was done in error, please ignore this.";
-						api.sendMessage(messageText, validID['userID']);
-						return setImmediate(callback);
-					}
-				});
-			}
-		});
-	}, cb);
+    async.forEach(message.body.split(module.exports.matchPattern).slice(1), function (frag, callback) {
+        mentioned = frag.split(" ").slice(0,2).join(" ");
+        var id = getIDByFirstName(mentioned.split(" ")[0], message);
+        if (id)
+            return sendMentionMessage(api, mentioned, id, message, callback);
+        
+        api.getUserID(mentioned, function (err, ids) {
+            if (err) {
+                console.log(err);
+                var errstring = err['error'];
+                //api.sendMessage({body: errstring}, message.threadID);
+                return setImmediate(callback);
+            } else if (message.participantIDs.indexOf(ids[0]['userID']) == -1 && message.participantIDs.indexOf(parseInt(ids[0]['userID'])) == -1) {
+                console.log("You can only mention people that are in the current thread.");
+                api.sendMessage("You can only mention people that are in the current thread.", message.threadID);
+            } else {
+                var validID = ids[0]['userID'];
+                return sendMentionMessage(api, mentioned, validID, message, callback);
+            }
+        });
+    }, cb);
 }

--- a/mentionsCache.js
+++ b/mentionsCache.js
@@ -1,0 +1,60 @@
+function ChatCache(chatID) {
+  this.chatID = chatID;
+  this.cache = {};
+}
+
+var nameToKey = function(name) {
+  return name.toLowerCase();
+}
+
+ChatCache.prototype.addFullName = function(name, userID) {
+  var key = nameToKey(name);
+  this.cache[key] = userID;
+}
+
+ChatCache.prototype.getIDByFirstName = function(name) {
+  var matchCount = 0;
+  var match;
+  for (var fullName in this.cache) {
+    if (!this.cache.hasOwnProperty(fullName))
+      continue;
+
+    if (fullName.split(" ")[0] == name) {
+      matchCount++;
+      match = this.cache[fullName];
+    }
+  }
+
+  // Only match on first name if the first name is unambiguous
+  if (matchCount == 1)
+    return match;
+  return null;
+}
+
+ChatCache.prototype.getID = function(name) {
+  var fullNameKey = nameToKey(name);
+  if (this.cache[fullNameKey])
+    return this.cache[fullNameKey];
+
+  var firstName = nameToKey(name.split(" ")[0]);
+  return this.getIDByFirstName(firstName);
+}
+
+var MentionsCache = function() {
+  this.cache = {}
+}
+
+MentionsCache.prototype.addToCache = function(chatID, name, userID) {
+  if (!this.cache[chatID]) {
+    this.cache[chatID] = new ChatCache(chatID);
+  }
+  return this.cache[chatID].addFullName(name, userID);
+}
+
+MentionsCache.prototype.getID = function(chatID, name) {
+  if (this.cache[chatID])
+    return this.cache[chatID].getID(name);
+  return null;
+}
+
+module.exports.MentionsCache = MentionsCache;


### PR DESCRIPTION
Adds support for first name mentions by caching full name mentions. As of now, the cache never gets stale, so if someone gets full-name-mentioned, then leaves the chat, they would probably still be mentionable by first name indefinitely. 
